### PR TITLE
Updating from source 3.7.1

### DIFF
--- a/source/crypto.c
+++ b/source/crypto.c
@@ -259,7 +259,7 @@ void decArm9Bin(void *armHdr, u8 mode){
     u8 keyX[0x10];
     u8 keyY[0x10];
     u8 CTR[0x10];
-    u32 slot = mode ? 0x16 : 0x15;
+    u8 slot = mode ? 0x16 : 0x15;
 
     //Setup keys needed for arm9bin decryption
     memcpy(keyY, armHdr+0x10, 0x10);
@@ -290,7 +290,7 @@ void setKeyXs(void *armHdr){
     void *decKey = keyData+0x10;
     aes_setkey(0x11, key2, AES_KEYNORMAL, AES_INPUT_BE | AES_INPUT_NORMAL);
     aes_use_keyslot(0x11);
-    for(u32 slot = 0x19; slot < 0x20; slot++){
+    for(u8 slot = 0x19; slot < 0x20; slot++){
         aes(decKey, keyData, 1, NULL, AES_ECB_DECRYPT_MODE, 0);
         aes_setkey(slot, decKey, AES_KEYX, AES_INPUT_BE | AES_INPUT_NORMAL);
         *(u8*)(keyData+0xF) += 1;

--- a/source/draw.c
+++ b/source/draw.c
@@ -37,7 +37,7 @@ void clearScreen(void){
 
 void loadSplash(void){
     //Check if it's a no-screen-init A9LH boot via PDN_GPU_CNT
-    if (*((u8*)0x10141200) == 0x1) return;
+    if (*(u8*)0x10141200 == 0x1) return;
     clearScreen();
     if(fileRead(fb->top_left, "/rei/splash.bin", 0x46500) != 0) return;
     u64 i = 0xFFFFFF; while(--i) __asm("mov r0, r0"); //Less Ghetto sleep func

--- a/source/firm.h
+++ b/source/firm.h
@@ -12,7 +12,8 @@
 #define HID_PAD            ((~*(u16*)0x10146000) & 0xFFF)
 #define BUTTON_R1          (1 << 8)
 #define BUTTON_L1          (1 << 9)
-#define SAFEMODE           (BUTTON_L1 | BUTTON_R1 | 1 | (1 << 6))
+#define BUTTON_A           1
+#define SAFEMODE           (BUTTON_L1 | BUTTON_R1 | BUTTON_A | (1 << 6))
 
 void setupCFW(void);
 u8 loadFirm(void);

--- a/source/patches.c
+++ b/source/patches.c
@@ -54,7 +54,6 @@ void getfOpen(void *pos, u32 size, u32 *off){
     //Calculate fOpen
     u32 p9addr = *(u32*)(memsearch(pos, "ess9", size, 4) + 0xC);
     u32 p9off = (u32)(memsearch(pos, "code", size, 4) + 0x1FF);
-
     unsigned char pattern[] = {0xB0, 0x04, 0x98, 0x0D};
 
     *off = (u32)memsearch(pos, pattern, size, 4) - 2 - p9off + p9addr;


### PR DESCRIPTION
Always prevents losing AGB_FIRM saves, forces the last used options on a MCU reboot (can be overridden with A)